### PR TITLE
Fixed DEK Version inconsistancy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-infineasdk",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "InfineaSDK Cordova plugin",
   "cordova": {
     "id": "cordova-plugin-infineasdk",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<plugin id="cordova-plugin-infineasdk" version="1.0.11" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="cordova-plugin-infineasdk" version="1.0.12" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
     <name>InfineaSDKCordova</name>
     <js-module name="InfineaSDKCordova" src="www/InfineaSDKCordova.js">
         <clobbers target="Infinea" />

--- a/src/ios/InfineaSDKCordova.m
+++ b/src/ios/InfineaSDKCordova.m
@@ -123,6 +123,7 @@
 
 - (void)emsrGetKeyVersion:(CDVInvokedUrlCommand*)command{
     NSLog(@"Call emsrGetKeyVersion");
+    [NSThread sleepForTimeInterval:.2];
     
     CDVPluginResult* pluginResult = nil;
     int keyID = [command.arguments[0] intValue];


### PR DESCRIPTION
getEMSRKeyVersion didn't work consistently. Added a small sleep command and fixed the issue. Seems to be a timing issue within cordova with our SDK